### PR TITLE
Fixes not tracking or improper tracking when plugin is disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,6 @@ A RuneLite plugin to track the number of players chopping a tree.
 - Edge case when a player quickly switches the tree they're chopping, it'll fail to register the new tree
     - This is because we utilize animations for tracking, and sometimes the chopping animation doesn't stop even if you
       switch trees.
-- If you turn off the plugin and on again, it won't track trees **unless**:
-    - A player starts chopping a tree
-    - You log back in
-    - The trees spawn back in
-        - Leaving and coming back to the area
-        - The tree respawns
 - Rare instances where overlay will remain even when there are no people chopping the tree
 
 ## Future Plans


### PR DESCRIPTION
There was an issue where if you turn off the plugin and back on, it wouldn't properly track players chopping. It would not count the current players chopping the tree. With this PR, now anytime you login, restart the plugin, or your gamestate changes to loading, it will wait for trees and players to be added to their respective maps, and then it will determine who is chopping a tree.