### PR TITLE
Disable woodcutting guild, local player tracking, and regular trees

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 # Tree Counter
 
-A RuneLite plugin to track the number of players chopping a tree.
+A RuneLite plugin to track the number of players **other than yourself** chopping a tree.
 
 ![](preview.png)
 
 ## Known Issues
 
+- Whenever there are players chopping tree roots from the event, it will incorrectly increment the nearby tree
 - ~~Rare instances where overlay will remain even when there are no people chopping the tree~~
-  - Potentially resolved via [#6](https://github.com/Infinitay/tree-count-plugin/pull/6)
-  - If you encounter this issue, please open an issue with the tree's location and a description of what happened
+    - Potentially resolved via [#6](https://github.com/Infinitay/tree-count-plugin/pull/6)
+    - If you encounter this issue, please open an issue with the tree's location and a description of what happened
 
 ## Future Plans
 

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 }
 
 group = 'treecount'
-version = '1.0'
+version = '1.1'
 
 tasks.withType(JavaCompile) {
 	options.encoding = 'UTF-8'

--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -1,6 +1,6 @@
 displayName=Tree Count
 author=infinitay
-description=A RuneLite plugin to track the number of players chopping a tree
+description=A RuneLite plugin to track the number of players other than yourself chopping a tree
 tags=woodcutting,wc,tree,count,forestry
 plugins=treecount.TreeCountPlugin
 support=https://github.com/Infinitay/tree-count-plugin

--- a/src/main/java/treecount/TreeCountOverlay.java
+++ b/src/main/java/treecount/TreeCountOverlay.java
@@ -38,6 +38,10 @@ public class TreeCountOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
+		if (plugin.isRegionInWoodcuttingGuild(client.getLocalPlayer().getWorldLocation().getRegionID())) {
+			return null;
+		}
+
 		// renderDebugOverlay(graphics);
 
 		for (Map.Entry<GameObject, Integer> treeEntry : plugin.getTreeMap().entrySet())

--- a/src/main/java/treecount/TreeCountOverlay.java
+++ b/src/main/java/treecount/TreeCountOverlay.java
@@ -38,7 +38,8 @@ public class TreeCountOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		if (plugin.isRegionInWoodcuttingGuild(client.getLocalPlayer().getWorldLocation().getRegionID())) {
+		if (plugin.isRegionInWoodcuttingGuild(client.getLocalPlayer().getWorldLocation().getRegionID()))
+		{
 			return null;
 		}
 

--- a/src/main/java/treecount/TreeCountPlugin.java
+++ b/src/main/java/treecount/TreeCountPlugin.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import javax.inject.Inject;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -54,7 +55,7 @@ public class TreeCountPlugin extends Plugin
 	private final Map<GameObject, Integer> treeMap = new HashMap<>();
 	private final Map<Player, GameObject> playerMap = new HashMap<>();
 	// This map is used to track player orientation changes for only players that are chopping trees
-	private final Map<Player, Integer> playerOrientationMap = new HashMap<>();
+	private final Map<Player, Integer> playerOrientationMap = new ConcurrentHashMap<>();
 
 	private int previousPlane;
 

--- a/src/main/java/treecount/TreeCountPlugin.java
+++ b/src/main/java/treecount/TreeCountPlugin.java
@@ -87,7 +87,8 @@ public class TreeCountPlugin extends Plugin
 	@Subscribe
 	public void onGameTick(GameTick gameTick)
 	{
-		if (isRegionInWoodcuttingGuild(client.getLocalPlayer().getWorldLocation().getRegionID())) {
+		if (isRegionInWoodcuttingGuild(client.getLocalPlayer().getWorldLocation().getRegionID()))
+		{
 			return;
 		}
 
@@ -104,7 +105,12 @@ public class TreeCountPlugin extends Plugin
 		{
 			firstRun = false;
 			// Any missing players just in case, although it's not really required. Doesn't hurt since one time operation
-			client.getPlayers().forEach(player -> playerMap.putIfAbsent(player, null));
+			client.getPlayers().forEach(player -> {
+				if (!player.equals(client.getLocalPlayer()))
+				{
+					playerMap.putIfAbsent(player, null);
+				}
+			});
 			for (Player player : playerMap.keySet())
 			{
 				if (isWoodcutting(player) && !treeMap.isEmpty())
@@ -139,7 +145,8 @@ public class TreeCountPlugin extends Plugin
 		// Event runs first upon login
 		GameObject gameObject = event.getGameObject();
 
-		if (isRegionInWoodcuttingGuild(gameObject.getWorldLocation().getRegionID())) {
+		if (isRegionInWoodcuttingGuild(gameObject.getWorldLocation().getRegionID()))
+		{
 			return;
 		}
 
@@ -157,7 +164,8 @@ public class TreeCountPlugin extends Plugin
 	public void onGameObjectDespawned(final GameObjectDespawned event)
 	{
 		final GameObject gameObject = event.getGameObject();
-		if (isRegionInWoodcuttingGuild(gameObject.getWorldLocation().getRegionID())) {
+		if (isRegionInWoodcuttingGuild(gameObject.getWorldLocation().getRegionID()))
+		{
 			return;
 		}
 		Tree tree = Tree.findTree(gameObject.getId());
@@ -190,7 +198,13 @@ public class TreeCountPlugin extends Plugin
 		Player player = event.getPlayer();
 		log.debug("Player {} spawned at {}", player.getName(), player.getWorldLocation());
 
-		if (isRegionInWoodcuttingGuild(player.getWorldLocation().getRegionID())) {
+		if (player.equals(client.getLocalPlayer()))
+		{
+			return;
+		}
+
+		if (isRegionInWoodcuttingGuild(player.getWorldLocation().getRegionID()))
+		{
 			return;
 		}
 
@@ -211,7 +225,13 @@ public class TreeCountPlugin extends Plugin
 	{
 		Player player = event.getPlayer();
 
-		if (isRegionInWoodcuttingGuild(player.getWorldLocation().getRegionID())) {
+		if (player.equals(client.getLocalPlayer()))
+		{
+			return;
+		}
+
+		if (isRegionInWoodcuttingGuild(player.getWorldLocation().getRegionID()))
+		{
 			return;
 		}
 
@@ -237,7 +257,13 @@ public class TreeCountPlugin extends Plugin
 		{
 			Player player = (Player) event.getActor();
 
-			if (client.getGameState() != GameState.LOGGING_IN && isRegionInWoodcuttingGuild(player.getWorldLocation().getRegionID())) {
+			if (player.equals(client.getLocalPlayer()))
+			{
+				return;
+			}
+
+			if (client.getGameState() == GameState.LOGGED_IN && isRegionInWoodcuttingGuild(player.getWorldLocation().getRegionID()))
+			{
 				return;
 			}
 
@@ -265,7 +291,13 @@ public class TreeCountPlugin extends Plugin
 
 		Player player = event.getPlayer();
 
-		if (isRegionInWoodcuttingGuild(player.getWorldLocation().getRegionID())) {
+		if (player.equals(client.getLocalPlayer()))
+		{
+			return;
+		}
+
+		if (isRegionInWoodcuttingGuild(player.getWorldLocation().getRegionID()))
+		{
 			return;
 		}
 
@@ -439,7 +471,8 @@ public class TreeCountPlugin extends Plugin
 		}
 	}
 
-	boolean isRegionInWoodcuttingGuild(int regionID) {
+	boolean isRegionInWoodcuttingGuild(int regionID)
+	{
 		return regionID == 6198 || regionID == 6454;
 	}
 }

--- a/src/main/java/treecount/TreeCountPlugin.java
+++ b/src/main/java/treecount/TreeCountPlugin.java
@@ -87,6 +87,10 @@ public class TreeCountPlugin extends Plugin
 	@Subscribe
 	public void onGameTick(GameTick gameTick)
 	{
+		if (isRegionInWoodcuttingGuild(client.getLocalPlayer().getWorldLocation().getRegionID())) {
+			return;
+		}
+
 		// Event runs third (or last) upon login
 		int currentPlane = client.getPlane();
 		if (previousPlane != currentPlane)
@@ -134,6 +138,12 @@ public class TreeCountPlugin extends Plugin
 	{
 		// Event runs first upon login
 		GameObject gameObject = event.getGameObject();
+
+		if (isRegionInWoodcuttingGuild(gameObject.getWorldLocation().getRegionID())) {
+			return;
+		}
+
+
 		Tree tree = Tree.findTree(gameObject.getId());
 
 		if (tree != null && !tree.equals(Tree.REGULAR_TREE))
@@ -146,14 +156,16 @@ public class TreeCountPlugin extends Plugin
 	@Subscribe
 	public void onGameObjectDespawned(final GameObjectDespawned event)
 	{
-		final GameObject object = event.getGameObject();
-
-		Tree tree = Tree.findTree(object.getId());
+		final GameObject gameObject = event.getGameObject();
+		if (isRegionInWoodcuttingGuild(gameObject.getWorldLocation().getRegionID())) {
+			return;
+		}
+		Tree tree = Tree.findTree(gameObject.getId());
 		if (tree != null && !tree.equals(Tree.REGULAR_TREE))
 		{
-			if (treeMap.containsKey(object))
+			if (treeMap.containsKey(gameObject))
 			{
-				treeMap.remove(object);
+				treeMap.remove(gameObject);
 			}
 		}
 
@@ -178,6 +190,10 @@ public class TreeCountPlugin extends Plugin
 		Player player = event.getPlayer();
 		log.debug("Player {} spawned at {}", player.getName(), player.getWorldLocation());
 
+		if (isRegionInWoodcuttingGuild(player.getWorldLocation().getRegionID())) {
+			return;
+		}
+
 		if (firstRun)
 		{
 			playerMap.put(player, null);
@@ -194,6 +210,10 @@ public class TreeCountPlugin extends Plugin
 	public void onPlayerDespawned(final PlayerDespawned event)
 	{
 		Player player = event.getPlayer();
+
+		if (isRegionInWoodcuttingGuild(player.getWorldLocation().getRegionID())) {
+			return;
+		}
 
 		if (firstRun)
 		{
@@ -216,6 +236,11 @@ public class TreeCountPlugin extends Plugin
 		if (event.getActor() instanceof Player)
 		{
 			Player player = (Player) event.getActor();
+
+			if (client.getGameState() != GameState.LOGGING_IN && isRegionInWoodcuttingGuild(player.getWorldLocation().getRegionID())) {
+				return;
+			}
+
 			if (isWoodcutting(player) && !treeMap.isEmpty())
 			{
 				addToTreeFocusedMaps(player);
@@ -239,6 +264,10 @@ public class TreeCountPlugin extends Plugin
 		}
 
 		Player player = event.getPlayer();
+
+		if (isRegionInWoodcuttingGuild(player.getWorldLocation().getRegionID())) {
+			return;
+		}
 
 		removeFromTreeMaps(player); // Remove the previous tracked case
 		if (isWoodcutting(player))
@@ -408,5 +437,9 @@ public class TreeCountPlugin extends Plugin
 		{
 			return new Direction[]{primaryDirection, null};
 		}
+	}
+
+	boolean isRegionInWoodcuttingGuild(int regionID) {
+		return regionID == 6198 || regionID == 6454;
 	}
 }

--- a/src/main/java/treecount/TreeCountPlugin.java
+++ b/src/main/java/treecount/TreeCountPlugin.java
@@ -135,7 +135,7 @@ public class TreeCountPlugin extends Plugin
 		GameObject gameObject = event.getGameObject();
 		Tree tree = Tree.findTree(gameObject.getId());
 
-		if (tree != null)
+		if (tree != null && !tree.equals(Tree.REGULAR_TREE))
 		{
 			log.debug("Tree {} spawned at {}", tree, gameObject.getLocalLocation());
 			treeMap.put(gameObject, 0);
@@ -148,7 +148,7 @@ public class TreeCountPlugin extends Plugin
 		final GameObject object = event.getGameObject();
 
 		Tree tree = Tree.findTree(object.getId());
-		if (tree != null)
+		if (tree != null && !tree.equals(Tree.REGULAR_TREE))
 		{
 			if (treeMap.containsKey(object))
 			{


### PR DESCRIPTION
- (soft) Disable tracking when at the woodcutting guild
	- The new invisible boost changes don't apply when you're chopping trees within the woodcutting guild
	- Handled via region id so it will also not track the trees outside but near the woodcutting guild
-  Don't track local player
	- The hidden boost is applied based on the number of **other** players chopping a tree
	- The number tracked and displayed on the trees now correlates to the number of **other** players chopping a tree
- Don't track regular trees
- Update to version 1.1