### PR TITLE
Add more Tree support, fix improper tracking (#10), fix NPE

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ A RuneLite plugin to track the number of players **other than yourself** choppin
 
 ## Known Issues
 
-- Whenever there are players chopping tree roots from the event, it will incorrectly increment the nearby tree
 - ~~Rare instances where overlay will remain even when there are no people chopping the tree~~
     - Potentially resolved via [#6](https://github.com/Infinitay/tree-count-plugin/pull/6)
     - If you encounter this issue, please open an issue with the tree's location and a description of what happened

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = 'latest.release'
+def runeLiteVersion = '1.10.8-SNAPSHOT'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
@@ -24,7 +24,7 @@ dependencies {
 }
 
 group = 'treecount'
-version = '1.1'
+version = '1.2'
 
 tasks.withType(JavaCompile) {
 	options.encoding = 'UTF-8'

--- a/src/main/java/treecount/Tree.java
+++ b/src/main/java/treecount/Tree.java
@@ -27,53 +27,95 @@ package treecount;
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import lombok.Getter;
-import net.runelite.api.NullObjectID;
-import static net.runelite.api.NullObjectID.NULL_10823;
-import static net.runelite.api.NullObjectID.NULL_10835;
 import net.runelite.api.ObjectID;
 import static net.runelite.api.ObjectID.*;
 
 @Getter
 public enum Tree
 {
-	REGULAR_TREE(TREE, TREE_1277, TREE_1278, TREE_1279, TREE_1280, TREE_40750, TREE_40752),
-	OAK_TREE(OAK_TREE_4540, OAK_10820),
-	WILLOW_TREE(WILLOW, WILLOW_10829, WILLOW_10831, WILLOW_10833),
-	TEAK_TREE(TEAK, TEAK_36686, TEAK_40758),
-	MAPLE_TREE(MAPLE_TREE_10832, MAPLE_TREE_36681, MAPLE_TREE_40754),
-	ARCTIC_PINE_TREE(ARCTIC_PINE),
-	HOLLOW_TREE(ObjectID.HOLLOW_TREE, HOLLOW_TREE_10821, HOLLOW_TREE_10830),
-	MAHOGANY_TREE(MAHOGANY, MAHOGANY_36688, MAHOGANY_40760),
-	YEW_TREE(YEW, NULL_10823, YEW_36683, YEW_40756),
-	MAGIC_TREE(MAGIC_TREE_10834, NULL_10835),
-	REDWOOD_TREE(ObjectID.REDWOOD, REDWOOD_29670, NullObjectID.NULL_34633, NullObjectID.NULL_34635, NullObjectID.NULL_34637, NullObjectID.NULL_34639, ObjectID.REDWOOD_TREE_34284, ObjectID.REDWOOD_TREE_34286, ObjectID.REDWOOD_TREE_34288, ObjectID.REDWOOD_TREE_34290);
+	// Trees that provide a hidden boost to woodcutting when chopping in a group
+	OAK_TREE(true, OAK_TREE_9734, OAK_TREE_10820, OAK_TREE_37969, OAK_TREE_42395, OAK_TREE_42831),
+	WILLOW_TREE(true, WILLOW_TREE_10819, WILLOW_TREE_10829, WILLOW_TREE_10831, WILLOW_TREE_10833),
+	TEAK_TREE(true, ObjectID.TEAK_TREE, TEAK_TREE_15062, TEAK_TREE_36686, TEAK_TREE_40758),
+	MAPLE_TREE(true, MAPLE_TREE_4674, MAPLE_TREE_10832, MAPLE_TREE_36681, MAPLE_TREE_40754),
+	ARCTIC_PINE_TREE(true, ObjectID.ARCTIC_PINE_TREE),
+	HOLLOW_TREE(true, HOLLOW_TREE_10821, HOLLOW_TREE_10830),
+	MAHOGANY_TREE(true, ObjectID.MAHOGANY_TREE, MAHOGANY_TREE_40760),
+	YEW_TREE(true, YEW_TREE_10822, YEW_TREE_36683, YEW_TREE_40756, YEW_TREE_42391),
+	MAGIC_TREE(true, MAGIC_TREE_10834, MAGIC_TREE_36685), // 36685 seems deprecated or placeholder for now, 0 locations as of July 2023
+	REDWOOD_TREE(true, ObjectID.REDWOOD_TREE, REDWOOD_TREE_29670, REDWOOD_TREE_34284, REDWOOD_TREE_34286, REDWOOD_TREE_34288, REDWOOD_TREE_34290),
 
+	// Trees that do not provide a hidden boost to woodcutting when chopping in a group and other choppable trees
+	REGULAR_TREE(false, ObjectID.TREE, TREE_1277, TREE_1278, TREE_1279, TREE_1280, TREE_1330, TREE_1331, TREE_1332, TREE_2409, TREE_3879,
+		TREE_3881, TREE_3882, TREE_3883, TREE_9730, TREE_9731, TREE_9732, TREE_9733, TREE_14308, TREE_14309, TREE_16264, TREE_16265, TREE_36672, TREE_36674,
+		TREE_36677, TREE_36679, TREE_37965, TREE_37967, TREE_37971, TREE_37973, TREE_40750, TREE_40752, TREE_42393, TREE_42832),
+	DEAD_TREE(false, ObjectID.DEAD_TREE, DEAD_TREE_1283, DEAD_TREE_1284, DEAD_TREE_1285, DEAD_TREE_1286, DEAD_TREE_1289, DEAD_TREE_1290, DEAD_TREE_1291, DEAD_TREE_1365, DEAD_TREE_1383,
+		DEAD_TREE_1384, DEAD_TREE_5902, DEAD_TREE_5903, DEAD_TREE_5904, DEAD_TREE_42907),
+	DRAMEN_TREE(false, ObjectID.DRAMEN_TREE),
+	EVERGREEN_TREE(false, ObjectID.EVERGREEN_TREE, EVERGREEN_TREE_1319, EVERGREEN_TREE_2091, EVERGREEN_TREE_2092, EVERGREEN_TREE_27060, EVERGREEN_TREE_40932, EVERGREEN_TREE_40933),
+	ACHEY_TREE(false, ObjectID.ACHEY_TREE),
+	JUNGLE_TREE(false, ObjectID.JUNGLE_TREE, JUNGLE_TREE_2889, JUNGLE_TREE_2890, JUNGLE_TREE_4818, JUNGLE_TREE_4820),
+	DYING_TREE(false, ObjectID.DYING_TREE),
+	DREAM_TREE(false, ObjectID.DREAM_TREE),
+	WINDSWEPT_TREE(false, WINDSWEPT_TREE_18137),
+	MATURE_JUNIPER_TREE(false, ObjectID.MATURE_JUNIPER_TREE),
+	BURNT_TREE(false, ObjectID.BURNT_TREE, BURNT_TREE_30854),
+	BLISTERWOOD_TREE(false, ObjectID.BLISTERWOOD_TREE),
+	RISING_ROOTS(false, TREE_ROOTS, ANIMAINFUSED_TREE_ROOTS);
+
+
+	private final boolean providesForestryBoost;
 	private final int[] treeIds;
 
-	Tree(int... treeIds)
+	Tree(boolean providesForestryBoost, int... treeIds)
 	{
+		this.providesForestryBoost = providesForestryBoost;
 		this.treeIds = treeIds;
 	}
 
-	private static final Map<Integer, Tree> TREES;
+	private static final Map<Integer, Tree> ALL_TREES;
+	private static final Map<Integer, Tree> FORESTRY_TREES;
 
 	static
 	{
-		ImmutableMap.Builder<Integer, Tree> builder = new ImmutableMap.Builder<>();
+		ImmutableMap.Builder<Integer, Tree> allTreesBuilder = new ImmutableMap.Builder<>();
+		ImmutableMap.Builder<Integer, Tree> forestryTreesBuilder = new ImmutableMap.Builder<>();
 
 		for (Tree tree : values())
 		{
 			for (int treeId : tree.treeIds)
 			{
-				builder.put(treeId, tree);
+				allTreesBuilder.put(treeId, tree);
+				if (tree.providesForestryBoost)
+				{
+					forestryTreesBuilder.put(treeId, tree);
+				}
 			}
 		}
 
-		TREES = builder.build();
+		ALL_TREES = allTreesBuilder.build();
+		FORESTRY_TREES = forestryTreesBuilder.build();
 	}
 
+	/**
+	 * Finds the tree that matches the given object ID
+	 *
+	 * @param objectId
+	 * @return tree that matches the given object ID, or null if no match
+	 */
 	static Tree findTree(int objectId)
 	{
-		return TREES.get(objectId);
+		return ALL_TREES.get(objectId);
+	}
+
+	/**
+	 * Finds the tree that is able to receive a forestry hidden boost that matches the given object ID
+	 *
+	 * @param objectId
+	 * @return forestry-boost-capable tree that matches the given object ID, or null if no match
+	 */
+	static Tree findForestryTree(int objectId)
+	{
+		return FORESTRY_TREES.get(objectId);
 	}
 }

--- a/src/main/java/treecount/TreeCountOverlay.java
+++ b/src/main/java/treecount/TreeCountOverlay.java
@@ -47,6 +47,11 @@ public class TreeCountOverlay extends Overlay
 
 		for (Map.Entry<GameObject, Integer> treeEntry : plugin.getTreeMap().entrySet())
 		{
+			if (Tree.findForestryTree(treeEntry.getKey().getId()) == null)
+			{
+				continue;
+			}
+
 			int choppers = treeEntry.getValue();
 			if (choppers > 0)
 			{

--- a/src/main/java/treecount/TreeCountPlugin.java
+++ b/src/main/java/treecount/TreeCountPlugin.java
@@ -150,10 +150,9 @@ public class TreeCountPlugin extends Plugin
 			return;
 		}
 
-
 		Tree tree = Tree.findTree(gameObject.getId());
 
-		if (tree != null && !tree.equals(Tree.REGULAR_TREE))
+		if (tree != null)
 		{
 			log.debug("Tree {} spawned at {}", tree, gameObject.getLocalLocation());
 			treeMap.put(gameObject, 0);
@@ -257,12 +256,14 @@ public class TreeCountPlugin extends Plugin
 		{
 			Player player = (Player) event.getActor();
 
-			if (player.equals(client.getLocalPlayer()))
+			if (player != null && player.equals(client.getLocalPlayer()))
 			{
 				return;
 			}
 
-			if (client.getGameState() == GameState.LOGGED_IN && isRegionInWoodcuttingGuild(player.getWorldLocation().getRegionID()))
+			// Check combat level to avoid NPE. Not sure why this happens, maybe the Player isn't really a player?
+			// The player isn't null, but all the fields are
+			if (player.getCombatLevel() != 0 && isRegionInWoodcuttingGuild(player.getWorldLocation().getRegionID()))
 			{
 				return;
 			}


### PR DESCRIPTION
- Fixed improper tracking (#10)
	- One case is during a rising roots forestry event
	- When a nearby player was performing the chopping animation on an unsupported tree, it would track it as chopping another nearby tree instead
- Updated Tree support
	- Now catalogues most if not all choppable (non-farming) trees
	- These states are still tracked to help prevent issues such as #10 but are not shown in the overlay unless they were to provide a boost
- Fixed a NPE occurring within onAnimationChanged event
	- Not sure why this was happening, but it occurred 100% of the time when initially logging into the game
		- Can reproduce on a fresh client start, log in to the middle of people chopping on a forestry world
	- Sometimes would still throw NPEs afterwards
	- The problem was `player.getWorldLocation()` was throwing NPE, even when null checking it (!)
		- player was not null
		- My guess is that even with the `instanceof` check, the type wasn't a player, or maybe it was a fake event
		- #getName would properly return null and #getCombatLevel returns 0, so I suppose you could use either to mitigate this issue, I opted for the first option
- Updated to version 1.2 