### PR TITLE
Different way of determining what tree a player is chopping

### DIFF
--- a/src/main/java/treecount/TreeCountConfig.java
+++ b/src/main/java/treecount/TreeCountConfig.java
@@ -2,8 +2,27 @@ package treecount;
 
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
 
 @ConfigGroup("treecount")
 public interface TreeCountConfig extends Config
 {
+	@ConfigItem(
+		keyName = "renderTreeTiles",
+		name = "(Debug) Show tree tiles",
+		description = "Configures whether to show debug info of tree tiles"
+	)
+	default boolean renderTreeTiles()
+	{
+		return false;
+	}
+	@ConfigItem(
+		keyName = "renderFacingTree",
+		name = "(Debug) Show facing tree",
+		description = "Configures whether to show debug info about the tree the player is facing"
+	)
+	default boolean renderFacingTree()
+	{
+		return false;
+	}
 }


### PR DESCRIPTION
Determine what a player is chopping by storing all the tiles of trees in a `HashMap` and querying it with the tile that the player is facing. This should speed up the original code while also using a bit more memory (probably still negligible?). I don't believe there are any cases in forestry where the target of chopping isn't the tile in the direction you're facing.

There also is some other stuff in here to tidy up some code but that can be picked through if needed.