### PR TITLE
Fix mishandling player orientation map and logic

### DIFF
--- a/src/main/java/treecount/TreeCountPlugin.java
+++ b/src/main/java/treecount/TreeCountPlugin.java
@@ -103,12 +103,12 @@ public class TreeCountPlugin extends Plugin
 
 		if (firstRun)
 		{
-			firstRun = false;
 			// Any missing players just in case, although it's not really required. Doesn't hurt since one time operation
 			client.getPlayers().forEach(player -> {
 				if (!player.equals(client.getLocalPlayer()))
 				{
 					playerMap.putIfAbsent(player, null);
+					playerOrientationMap.put(player, -1);
 				}
 			});
 			for (Player player : playerMap.keySet())
@@ -131,11 +131,15 @@ public class TreeCountPlugin extends Plugin
 
 				if (currentOrientation != previousOrientation)
 				{
-					playerOrientationMap.put(player, currentOrientation);
 					final PlayerOrientationChanged playerOrientationChanged = new PlayerOrientationChanged(player, previousOrientation, currentOrientation);
 					onPlayerOrientationChanged(playerOrientationChanged);
 				}
 			}
+		}
+
+		if (firstRun)
+		{
+			firstRun = false;
 		}
 	}
 
@@ -292,6 +296,8 @@ public class TreeCountPlugin extends Plugin
 
 		Player player = event.getPlayer();
 
+		log.debug("Player {} orientation changed from {} to {}", player.getName(), event.getPreviousOrientation(), event.getCurrentOrientation());
+
 		if (player.equals(client.getLocalPlayer()))
 		{
 			return;
@@ -302,6 +308,7 @@ public class TreeCountPlugin extends Plugin
 			return;
 		}
 
+		playerOrientationMap.put(player, event.getCurrentOrientation());
 		removeFromTreeMaps(player); // Remove the previous tracked case
 		if (isWoodcutting(player))
 		{
@@ -341,7 +348,6 @@ public class TreeCountPlugin extends Plugin
 			return false;
 		}
 		playerMap.put(player, closestTree);
-		playerOrientationMap.put(player, player.getOrientation());
 		int choppers = treeMap.getOrDefault(closestTree, 0) + 1;
 		treeMap.put(closestTree, choppers);
 		return true;
@@ -351,7 +357,6 @@ public class TreeCountPlugin extends Plugin
 	{
 		GameObject tree = playerMap.get(player);
 		playerMap.remove(player);
-		playerOrientationMap.remove(player);
 		if (treeMap.containsKey(tree))
 		{
 			int choppers = treeMap.getOrDefault(tree, 1) - 1;


### PR DESCRIPTION
- Now instantiates the player orientation map with values on first start
- Moved player orientation map updating (#put) to within the event handler #onPlayerOrientationChanged instead of #onGameTick
- No longer updates orientation whenever we add a tree to the tree map in #addToTreeFocusedMaps
- Stopped removing the player orientation entries whenever we removed a tree from the tree map in #removeFromTreeMaps
    - We should have never removed it here to begin with, only when a player despawns

Came across this issue when reviewing #15. Before these changes, the new focused-tree determination was not working when a player shifts their orientation as they are chopping. After these changes, the issue has been resolved and #15 works fine.