### PR TITLE
Release v1.5 - Fixed logic issues with counting choppers (#25)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 }
 
 group = 'treecount'
-version = '1.4'
+version = '1.5'
 
 tasks.withType(JavaCompile) {
 	options.encoding = 'UTF-8'

--- a/src/main/java/treecount/TreeCountConfig.java
+++ b/src/main/java/treecount/TreeCountConfig.java
@@ -7,7 +7,7 @@ import net.runelite.client.config.ConfigItem;
 @ConfigGroup("treecount")
 public interface TreeCountConfig extends Config
 {
-	boolean DEBUG = false;
+	boolean DEBUG = true;
 
 	@ConfigItem(
 		keyName = "renderTreeHull",
@@ -21,7 +21,7 @@ public interface TreeCountConfig extends Config
 
 	@ConfigItem(
 		keyName = "renderTreeTiles",
-		name = "(Debug) Show tree tiles",
+		name = "(Debug) Show Tree Tiles",
 		description = "Configures whether to show debug info of tree tiles",
 		hidden = !DEBUG
 	)
@@ -32,11 +32,55 @@ public interface TreeCountConfig extends Config
 
 	@ConfigItem(
 		keyName = "renderFacingTree",
-		name = "(Debug) Show facing tree",
+		name = "(Debug) Show Facing Tree",
 		description = "Configures whether to show debug info about the tree the player is facing",
 		hidden = !DEBUG
 	)
 	default boolean renderFacingTree()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "includeSelf",
+		name = "(Debug) Include Self",
+		description = "Configures whether to help with debug info by including the player in the tree count",
+		hidden = !DEBUG
+	)
+	default boolean includeSelf()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "enableWCGuild",
+		name = "(Debug) Enable Woodcutting Guild",
+		description = "Configures whether to help with debug info by allowing the woodcutting guild to be used",
+		hidden = !DEBUG
+	)
+	default boolean enableWCGuild()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "renderPlayerOrientation",
+		name = "(Debug) Show Player Orientation",
+		description = "Configures whether to show debug info about the tree hull",
+		hidden = !DEBUG
+	)
+	default boolean renderPlayerOrientation()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "renderExpectedChoppers",
+		name = "(Debug) Show Expected Choppers",
+		description = "Configures whether to show debug info about the expected number of people chopping a tree",
+		hidden = !DEBUG
+	)
+	default boolean renderExpectedChoppers()
 	{
 		return false;
 	}


### PR DESCRIPTION
Debug Additions
 - Allow local player to be tracked
 - Allow for the plugin to work within the WC guild
 - Display player orientation and direction above players
 - Display expected players chopping a tree (if there are adjacent trees it will count for those too)
 - General log additions

Logic Fixes
 - onPlayerSpawned
    - Ignores on first run since it's handled on gametime
    - Now checks to see if the player was already added to the map and therefore the tree map, if so then it doesnt re-add it
    - Fixes issue of constantly incrementing count when a player spawns again such as by moving your player out and back in range
 - onPlayerDespawned
    - Removed unneccessary if-first-run check that didn't allow it to remove tree counts since it was returning early

https://github.com/Infinitay/tree-count-plugin/assets/6964154/1f6ba839-9618-4229-97c7-6fb58ea6f026

