### PR TITLE
Release 1.5.1 - Woodcutting animation-stall workaround (#24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ A RuneLite plugin to track the number of players **other than yourself** choppin
 
 ## Known Issues
 
+- Edgecase where number of people chopping a tree is incorrect and missing people [(#24)](https://github.com/Infinitay/tree-count-plugin/pull/6)
+    - This occurs when the player is chopping a tree but is not facing the tree due to an animation stall bug
+    - More common with felling axes and potentially a rare occurrence with regular axes
+    - I made a temporary hotfix for this issue [#25](https://github.com/Infinitay/tree-count-plugin/pull/25), but it is not a permanent solution until Jagex fixes animations when interacting
 - ~~Rare instances where overlay will remain even when there are no people chopping the tree~~
     - Potentially resolved via [#6](https://github.com/Infinitay/tree-count-plugin/pull/6)
     - If you encounter this issue, please open an issue with the tree's location and a description of what happened

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ A RuneLite plugin to track the number of players **other than yourself** choppin
     - This occurs when the player is chopping a tree but is not facing the tree due to an animation stall bug
     - More common with felling axes and potentially a rare occurrence with regular axes
     - I made a temporary hotfix for this issue [#27](https://github.com/Infinitay/tree-count-plugin/pull/27), but it is not a permanent solution until Jagex fixes animations when interacting
+      - A player is said to be chopping a tree if it is facing a tree and has the chopping animation
+      - If there is no facing tree found but the player is chopping, then the player is said to be chopping the tree they are standing right beside a tree IF AND ONLY IF they are standing by one tree.
 - ~~Rare instances where overlay will remain even when there are no people chopping the tree~~
     - Potentially resolved via [#6](https://github.com/Infinitay/tree-count-plugin/pull/6)
     - If you encounter this issue, please open an issue with the tree's location and a description of what happened

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A RuneLite plugin to track the number of players **other than yourself** choppin
 - Edgecase where number of people chopping a tree is incorrect and missing people [(#24)](https://github.com/Infinitay/tree-count-plugin/pull/6)
     - This occurs when the player is chopping a tree but is not facing the tree due to an animation stall bug
     - More common with felling axes and potentially a rare occurrence with regular axes
-    - I made a temporary hotfix for this issue [#25](https://github.com/Infinitay/tree-count-plugin/pull/25), but it is not a permanent solution until Jagex fixes animations when interacting
+    - I made a temporary hotfix for this issue [#27](https://github.com/Infinitay/tree-count-plugin/pull/27), but it is not a permanent solution until Jagex fixes animations when interacting
 - ~~Rare instances where overlay will remain even when there are no people chopping the tree~~
     - Potentially resolved via [#6](https://github.com/Infinitay/tree-count-plugin/pull/6)
     - If you encounter this issue, please open an issue with the tree's location and a description of what happened

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 }
 
 group = 'treecount'
-version = '1.5'
+version = '1.5.1'
 
 tasks.withType(JavaCompile) {
 	options.encoding = 'UTF-8'

--- a/src/main/java/treecount/TreeCountOverlay.java
+++ b/src/main/java/treecount/TreeCountOverlay.java
@@ -238,7 +238,11 @@ public class TreeCountOverlay extends Overlay
 		Map<GameObject, Integer> expectedChoppers = new HashMap<>();
 		for (Player player : client.getPlayers())
 		{
-			plugin.getAdjacentTrees(player).forEach(tree ->
+			if (player.equals(client.getLocalPlayer()) && !config.includeSelf())
+			{
+				continue;
+			}
+			plugin.getAdjacentTrees(player, false).forEach(tree ->
 			{
 				if (plugin.isWoodcutting(player))
 				{


### PR DESCRIPTION
Core Changes
  - Temporarily fix animation-stalled players by utilising the adjacent tree (#24) - Added a new method `getAdjacentTrees` that returns a list of trees that are adjacent to an `Actor`
	- If the closest facing tree is not detected, it will check the adjacent trees. If there is only one then it will assume the player is chopping that respective tree - As commented in the original issue thread (#24), this is not a perfect solution as it will not use the fallback if that respective tree if they are adjacent to multiple trees
  - Split `#isWoodcutting` into two respective methods depending on whether the animation uses a regular or felling axe

Overlay Changes
  - Refactored `#renderPlayersAdjacentToTrees` in `TreeCountOverlay` - Relies on `#getAdjacentTrees`
	- Performance improvement due to not looping against all tree tiles

https://github.com/Infinitay/tree-count-plugin/assets/6964154/64571ce8-661c-4880-8329-7c9acd28ce3a


