### PR TITLE
Only track (forestry) trees capable of receiving a hidden boost

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 }
 
 group = 'treecount'
-version = '1.5.1'
+version = '1.5.2'
 
 tasks.withType(JavaCompile) {
 	options.encoding = 'UTF-8'

--- a/src/main/java/treecount/TreeCountPlugin.java
+++ b/src/main/java/treecount/TreeCountPlugin.java
@@ -184,7 +184,7 @@ public class TreeCountPlugin extends Plugin
 			return;
 		}
 
-		Tree tree = Tree.findTree(gameObject.getId());
+		Tree tree = Tree.findForestryTree(gameObject.getId());
 
 		if (tree != null)
 		{
@@ -226,7 +226,7 @@ public class TreeCountPlugin extends Plugin
 		{
 			return;
 		}
-		Tree tree = Tree.findTree(gameObject.getId());
+		Tree tree = Tree.findForestryTree(gameObject.getId());
 		if (tree != null && !tree.equals(Tree.REGULAR_TREE))
 		{
 			treeMap.remove(gameObject);
@@ -452,7 +452,7 @@ public class TreeCountPlugin extends Plugin
 			// This will treat the only adjacent tree as the tree the player is chopping
 			if (isWoodcutting(player))
 			{
-				List<GameObject> adjacentTrees = getAdjacentTrees(player, false);
+				List<GameObject> adjacentTrees = getAdjacentTrees(player, true);
 				if (adjacentTrees.size() == 1)
 				{
 					playerMap.put(player, adjacentTrees.get(0));


### PR DESCRIPTION
**Version 1.5.2 (ce01094b8e6bc1e35e0f6f9d60852820e9234bcb) changes which trees are tracked now.**

The number of people chopping a tree is important to decide which tree to chop that would give the player the highest hidden boost due to the woodcutting changes that forestry brought to the skill. I decided that by limiting the trees it would benefit the workaround changes made in v1.5.1 ([1bf90e9](https://github.com/Infinitay/tree-count-plugin/pull/27/commits/1bf90e9eb1a0684d7d460d49ba34f1a75000fdfd)) by relying on an adjacency check to people woodcutting. It helps benefit more instances such as the two shown in the video where the player is animation stalled and there are plenty of regular trees surrounding them.

**However** this makes an assumption so I'm still considering whether or not to do this. For example, what if a player is between a non-forestry tree and forestry tree. They chop the non-forestry tree and get animation stalled. These changes will make it so that it will consider the player as chopping the forestry tree when that is false. It makes an assumption and is wrong. I think it would be better not miscount by having a false-negative (not including a chopper) rather than a false-positive (including a chopper).

https://github.com/Infinitay/tree-count-plugin/assets/6964154/8b00a4af-a61d-457c-93cb-eb896c9b0653

https://github.com/Infinitay/tree-count-plugin/assets/6964154/f447a27f-0ae4-4d2b-a503-c2b1c2d2f166

