### PR TITLE
Add missing imposter id for yew trees (#29)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 }
 
 group = 'treecount'
-version = '1.5.1'
+version = '1.5.2'
 
 tasks.withType(JavaCompile) {
 	options.encoding = 'UTF-8'

--- a/src/main/java/treecount/Tree.java
+++ b/src/main/java/treecount/Tree.java
@@ -27,6 +27,7 @@ package treecount;
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import lombok.Getter;
+import net.runelite.api.NullObjectID;
 import net.runelite.api.ObjectID;
 import static net.runelite.api.ObjectID.*;
 
@@ -41,7 +42,7 @@ public enum Tree
 	ARCTIC_PINE_TREE(true, ObjectID.ARCTIC_PINE_TREE),
 	HOLLOW_TREE(true, HOLLOW_TREE_10821, HOLLOW_TREE_10830),
 	MAHOGANY_TREE(true, ObjectID.MAHOGANY_TREE, ObjectID.MAHOGANY_TREE_40760, ObjectID.MAHOGANY),
-	YEW_TREE(true, ObjectID.YEW_TREE_10822, ObjectID.YEW_TREE_36683, ObjectID.YEW_TREE_40756, ObjectID.YEW_TREE_42391),
+	YEW_TREE(true, ObjectID.YEW_TREE_10822, NullObjectID.NULL_10823, ObjectID.YEW_TREE_36683, ObjectID.YEW_TREE_40756, ObjectID.YEW_TREE_42391), // 10823 is an imposter yew tree (see varrock or gnome yews)
 	MAGIC_TREE(true, MAGIC_TREE_10834, MAGIC_TREE_36685), // 36685 seems deprecated or placeholder for now, 0 locations as of July 2023
 	REDWOOD_TREE(true, ObjectID.REDWOOD_TREE, ObjectID.REDWOOD_TREE_29670, ObjectID.REDWOOD_TREE_34284, ObjectID.REDWOOD_TREE_34286, ObjectID.REDWOOD_TREE_34288, ObjectID.REDWOOD_TREE_34290),
 


### PR DESCRIPTION
Fixes #29 

![image](https://github.com/Infinitay/tree-count-plugin/assets/6964154/60ad03e9-5d22-4813-a125-772b9517eed4)

Some yew trees have what is known to be an imposter id (https://discord.com/channels/301497432909414422/419891709883973642/1176013071345520691). Most likely because the trees are locked behind quest areas because the GameObject ID of 10823 is for Yew Trees that are found both behind Varrock Palace and within the Gnome Stronghold.