### PR TITLE
Add option for static text colors and a color picker

### DIFF
--- a/src/main/java/treecount/TreeCountConfig.java
+++ b/src/main/java/treecount/TreeCountConfig.java
@@ -1,5 +1,6 @@
 package treecount;
 
+import java.awt.Color;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
@@ -18,6 +19,26 @@ public interface TreeCountConfig extends Config
 	{
 		return false;
 	}
+
+    @ConfigItem(
+            keyName = "dynamicColors",
+            name = "Dynamic Color",
+            description = "Use dynamic colors for the chopper count. If disabled, Text Color will be used"
+    )
+    default boolean dynamicColors()
+    {
+        return true;
+    }
+
+    @ConfigItem(
+            keyName = "textColor",
+            name = "Text Color",
+            description = "The color of the tree count text."
+    )
+    default Color textColor()
+    {
+        return Color.YELLOW;
+    }
 
 	@ConfigItem(
 		keyName = "renderTreeTiles",

--- a/src/main/java/treecount/TreeCountOverlay.java
+++ b/src/main/java/treecount/TreeCountOverlay.java
@@ -143,14 +143,23 @@ public class TreeCountOverlay extends Overlay
 		OverlayUtil.renderPolygon(graphics, gameObject.getConvexHull(), outlineColor, BLANK_COLOR, stroke);
 	}
 
-	private static Color getColorForChoppers(int choppers)
+	private Color getColorForChoppers(int choppers)
 	{
-		final float percent = Math.min(1f, choppers / 10f);
-		final float hue1 = rgbToHsbArray(Color.RED)[0];
-		final float hue2 = rgbToHsbArray(Color.GREEN)[0];
-		final float lerpedHue = hue1 + (hue2 - hue1) * percent;
-		return Color.getHSBColor(lerpedHue, 1f, 1f);
+        if(config.dynamicColors()) {
+            return getDynamicColor(choppers);
+        } else {
+            return config.textColor();
+        }
 	}
+
+    private static Color getDynamicColor(int choppers)
+    {
+        final float percent = Math.min(1f, choppers / 10f);
+        final float hue1 = rgbToHsbArray(Color.RED)[0];
+        final float hue2 = rgbToHsbArray(Color.GREEN)[0];
+        final float lerpedHue = hue1 + (hue2 - hue1) * percent;
+        return Color.getHSBColor(lerpedHue, 1f, 1f);
+    }
 
 	private static float[] rgbToHsbArray(Color color)
 	{


### PR DESCRIPTION
Resolves issue #21 

Adds a checkbox to enable dynamic colors which is enablekd by defaulkt, and when disabled uses the text color from the new picker

<img width="1068" height="505" alt="2025-08-26_09-57-43" src="https://github.com/user-attachments/assets/6f7a6996-9d63-48c8-bca9-fe453dccf9ff" />
<img width="1068" height="505" alt="2025-08-26_09-57-13" src="https://github.com/user-attachments/assets/e63083c0-7077-471f-a6a3-35a27e99800b" />
<img width="1068" height="505" alt="2025-08-26_09-57-08" src="https://github.com/user-attachments/assets/4be89da4-201a-4b06-ac5c-8de98cb3d3e3" />
